### PR TITLE
Use context of trans templatetag

### DIFF
--- a/django_babel/extract.py
+++ b/django_babel/extract.py
@@ -83,7 +83,18 @@ def extract_django(fileobj, keywords, comment_tags, options):
                         g = g.strip('"')
                     elif g[0] == "'":
                         g = g.strip("'")
-                    yield lineno, None, smart_text(g), []
+                    message_context = imatch.group(3)
+                    if message_context:
+                        # strip quotes
+                        message_context = message_context[1:-1]
+                        yield (
+                            lineno,
+                            'pgettext',
+                            [smart_text(message_context), smart_text(g)],
+                            [],
+                        )
+                    else:
+                        yield lineno, None, smart_text(g), []
                 elif bmatch:
                     for fmatch in constant_re.findall(t.contents):
                         yield lineno, None, smart_text(fmatch), []

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -30,6 +30,30 @@ class ExtractDjangoTestCase(unittest.TestCase):
         messages = list(extract_django(buf, default_keys, [], {}))
         self.assertEqual([(1, None, u'Bunny', [])], messages)
 
+    def test_extract_simple_with_context_single_quotes(self):
+        buf = BytesIO(b"{% trans 'Bunny' context 'carrot' %}")
+        messages = list(extract_django(buf, default_keys, [], {}))
+        self.assertEqual([(1, 'pgettext',
+                           [u'carrot', u'Bunny'], [])], messages)
+
+    def test_extract_simple_with_context_double_quotes(self):
+        buf = BytesIO(b"{% trans 'Bunny' context \"carrot\" %}")
+        messages = list(extract_django(buf, default_keys, [], {}))
+        self.assertEqual([(1, 'pgettext',
+                           [u'carrot', u'Bunny'], [])], messages)
+
+    def test_extract_simple_with_context_with_single_quotes(self):
+        buf = BytesIO(b"{% trans 'Bunny' context \"'carrot'\" %}")
+        messages = list(extract_django(buf, default_keys, [], {}))
+        self.assertEqual([(1, 'pgettext',
+                           [u'\'carrot\'', u'Bunny'], [])], messages)
+
+    def test_extract_simple_with_context_with_double_quotes(self):
+        buf = BytesIO(b"{% trans 'Bunny' context '\"carrot\"' %}")
+        messages = list(extract_django(buf, default_keys, [], {}))
+        self.assertEqual([(1, 'pgettext',
+                           [u'"carrot"', u'Bunny'], [])], messages)
+
     def test_extract_var(self):
         buf = BytesIO(b'{% blocktrans %}{{ anton }}{% endblocktrans %}')
         messages = list(extract_django(buf, default_keys, [], {}))


### PR DESCRIPTION
If I have `{% trans %}` with context, then I should yield `pgettext` function not to miss context
Fixes #18