### PR TITLE
`Lexer`'s __init__ only takes template_string as arg (django 1.9)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,30 +1,44 @@
-language: python
-python: 3.4
 sudo: false
+language: python
+python:
+  - "2.6"
+  - "2.7"
+  - "3.3"
+  - "3.4"
+  - "3.5"
 env:
-  - TOX_ENV=py27-django15
-  - TOX_ENV=py27-django16
-  - TOX_ENV=py27-django17
-  - TOX_ENV=py27-django18
-  - TOX_ENV=py27-djangomaster
-  - TOX_ENV=py33-django15
-  - TOX_ENV=py33-django16
-  - TOX_ENV=py33-django17
-  - TOX_ENV=py33-django18
-  - TOX_ENV=py33-djangomaster
-  - TOX_ENV=py34-django15
-  - TOX_ENV=py34-django16
-  - TOX_ENV=py34-django17
-  - TOX_ENV=py34-django18
-  - TOX_ENV=py34-djangomaster
-  - TOX_ENV=py26-django15
-  - TOX_ENV=py26-django16
-  - TOX_ENV=lint
-  - TOX_ENV=docs
+  - DJANGO_VERSION=master
+  - DJANGO_VERSION=1.9.x
+  - DJANGO_VERSION=1.8.x
+  - DJANGO_VERSION=1.7.x
+  - DJANGO_VERSION=1.6.x
+  - DJANGO_VERSION=1.5.x
 install:
-- pip install tox
+  - pip install tox
 script:
-- tox -e $TOX_ENV
+  - tox -e "$TRAVIS_PYTHON_VERSION-$DJANGO_VERSION"
+matrix:
+  exclude:
+   - python: "2.6"
+     env: DJANGO_VERSION=master
+   - python: "2.6"
+     env: DJANGO_VERSION=1.7.x
+   - python: "2.6"
+     env: DJANGO_VERSION=1.8.x
+   - python: "2.6"
+     env: DJANGO_VERSION=1.9.x
+   - python: "3.3"
+     env: DJANGO_VERSION=1.9.x
+   - python: "3.3"
+     env: DJANGO_VERSION=master
+   - python: "3.5"
+     env: DJANGO_VERSION=1.5.x
+   - python: "3.5"
+     env: DJANGO_VERSION=1.6.x
+   - python: "3.5"
+     env: DJANGO_VERSION=1.7.x
+   - python: "3.5"
+     env: DJANGO_VERSION=1.8.x
 cache:
   directories:
     - $HOME/.cache/pip

--- a/django_babel/extract.py
+++ b/django_babel/extract.py
@@ -33,7 +33,14 @@ def extract_django(fileobj, keywords, comment_tags, options):
     encoding = options.get('encoding', 'utf8')
     text = fileobj.read().decode(encoding)
 
-    for t in Lexer(text, None).tokenize():
+    try:
+        text_lexer = Lexer(text)
+    except TypeError:
+        # Django 1.9 changed the way we invoke Lexer; older versions
+        # require two parameters.
+        text_lexer = Lexer(text, None)
+
+    for t in text_lexer.tokenize():
         lineno += t.contents.count('\n')
         if intrans:
             if t.token_type == TOKEN_BLOCK:

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     url='https://github.com/python-babel/django-babel/',
     packages=find_packages(exclude=('tests',)),
     install_requires=[
-        'django>=1.4,<1.9',
+        'django>=1.4',
         'babel>=1.3',
     ],
     classifiers=[

--- a/tox.ini
+++ b/tox.ini
@@ -1,18 +1,135 @@
-[tox]
-envlist = {py27,py33,py34}-django{15,16,17,18,master}, py26-django{15,16}, lint, docs
-
 [testenv]
+skipsdist = True
+usedevelop = True
+commands =
+    pip install -e {toxinidir}
+    pip install -e {toxinidir}[tests]
+    py.test tests/
 deps =
     coverage
     pytest
     pytest-cov
     python-coveralls
-    django15: Django>=1.5,<1.6
-    django16: Django>=1.6,<1.7
-    django17: Django>=1.7,<1.8
-    django18: Django>=1.8,<1.9
-    djangomaster: https://github.com/django/django/archive/master.tar.gz#egg=Django
-commands = py.test {posargs}
+
+[testenv:2.6-1.5.x]
+basepython = python2.6
+deps =
+    {[testenv]deps}
+    Django>=1.5,<1.6
+
+[testenv:2.6-1.6.x]
+basepython = python2.6
+deps =
+    {[testenv]deps}
+    Django>=1.6,<1.7
+
+[testenv:2.7-1.5.x]
+basepython = python2.7
+deps =
+    {[testenv]deps}
+    Django>=1.5,<1.6
+
+[testenv:2.7-1.6.x]
+basepython = python2.7
+deps =
+    {[testenv]deps}
+    Django>=1.6,<1.7
+
+[testenv:2.7-1.7.x]
+basepython = python2.7
+deps =
+    {[testenv]deps}
+    Django>=1.7,<1.8
+
+[testenv:2.7-1.8.x]
+basepython = python2.7
+deps =
+    {[testenv]deps}
+    Django>=1.8,<1.9
+
+[testenv:2.7-1.9.x]
+basepython = python2.7
+deps =
+    {[testenv]deps}
+    Django>=1.9,<1.10
+
+[testenv:2.7-master]
+basepython = python2.7
+deps =
+    {[testenv]deps}
+    https://github.com/django/django/archive/master.tar.gz#egg=django
+
+[testenv:3.3-1.5.x]
+basepython = python3.3
+deps =
+    {[testenv]deps}
+    Django>=1.5,<1.6
+
+[testenv:3.3-1.6.x]
+basepython = python3.3
+deps =
+    {[testenv]deps}
+    Django>=1.6,<1.7
+
+[testenv:3.3-1.7.x]
+basepython = python3.3
+deps =
+    {[testenv]deps}
+    Django>=1.7,<1.8
+
+[testenv:3.3-1.8.x]
+basepython = python3.3
+deps =
+    {[testenv]deps}
+    Django>=1.8,<1.9
+
+[testenv:3.4-1.5.x]
+basepython = python3.4
+deps =
+    {[testenv]deps}
+    Django>=1.5,<1.6
+
+[testenv:3.4-1.6.x]
+basepython = python3.4
+deps =
+    {[testenv]deps}
+    Django>=1.6,<1.7
+
+[testenv:3.4-1.7.x]
+basepython = python3.4
+deps =
+    {[testenv]deps}
+    Django>=1.7,<1.8
+
+[testenv:3.4-1.8.x]
+basepython = python3.4
+deps =
+    {[testenv]deps}
+    Django>=1.8,<1.9
+
+[testenv:3.4-1.9.x]
+basepython = python3.4
+deps =
+    {[testenv]deps}
+    Django>=1.9,<1.10
+
+[testenv:3.4-master]
+basepython = python3.4
+deps =
+    {[testenv]deps}
+    https://github.com/django/django/archive/master.tar.gz#egg=django
+
+[testenv:3.5-1.9.x]
+basepython = python3.5
+deps =
+    {[testenv]deps}
+    Django>=1.9,<1.10
+
+[testenv:3.5-master]
+basepython = python3.5
+deps =
+    {[testenv]deps}
+    https://github.com/django/django/archive/master.tar.gz#egg=django
 
 [testenv:docs]
 deps = sphinx


### PR DESCRIPTION
This PR does three things:

1. Changes the way calls to `Lexer` are made, given that the `__init__ method has changed as of Django 1.9. The commit that changes the definition is here: https://github.com/django/django/commit/55f12f8709f0604df7e1817a4c114ead1fb9a311 and is first present in 1.9.1 tags.

2. Updates Travis and Tox to make a more readable Travis output. Previously, when visiting the Travis build page, you saw the Python version for the container, but had to parse the Tox environment variables to understand the real Python and Django versions being run:
![screen shot 2015-12-03 at 8 42 04 pm](https://cloud.githubusercontent.com/assets/1985317/11579734/6bf572d4-99fe-11e5-8270-008c92d34960.png)

  With my update, it is much easier to understand what versions are being run:
![screen shot 2015-12-03 at 8 42 18 pm](https://cloud.githubusercontent.com/assets/1985317/11579738/74782898-99fe-11e5-8a6c-c51792e09ce9.png)

3. Finally, I removed the restriction of Django version in setup.py. This was causing a frustrating silent failure in Travis, where the container would claim to be running Django 1.9 but was actually pulling in 1.8.7 because setup.py restricted the Django version to `<1.9`. Since we always test on `master`, we should leave this unbounded so we can always be apprised of failures (the `master` branch of Django always bumps the version up to the next-to-be released version; see https://github.com/django/django/blob/master/django/__init__.py#L5 which currently is already listing the version as 1.10.alpha)