### PR TITLE
Strip quotes from translations via _()

### DIFF
--- a/django_babel/templatetags/babel.py
+++ b/django_babel/templatetags/babel.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
 
 from babel import support as babel_support
 from babel import core as babel_core

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -154,17 +154,17 @@ class ExtractDjangoTestCase(unittest.TestCase):
     def test_extract_constant_single_quotes(self):
         buf = BytesIO(b"{{ _('constant') }}")
         messages = list(extract_django(buf, default_keys, [], {}))
-        self.assertEqual([(1, None, u"'constant'", [])], messages)
+        self.assertEqual([(1, None, u'constant', [])], messages)
 
     def test_extract_constant_double_quotes(self):
         buf = BytesIO(b'{{ _("constant") }}')
         messages = list(extract_django(buf, default_keys, [], {}))
-        self.assertEqual([(1, None, u'"constant"', [])], messages)
+        self.assertEqual([(1, None, u'constant', [])], messages)
 
     def test_extract_constant_block(self):
         buf = BytesIO(b'{% _("constant") %}')
         messages = list(extract_django(buf, default_keys, [], {}))
-        self.assertEqual([(1, None, u'"constant"', [])], messages)
+        self.assertEqual([(1, None, u'constant', [])], messages)
 
     def test_extract_constant_in_block(self):
         test_tmpl = (
@@ -173,7 +173,7 @@ class ExtractDjangoTestCase(unittest.TestCase):
         buf = BytesIO(test_tmpl)
         messages = list(extract_django(buf, default_keys, [], {}))
         self.assertEqual(
-            [(1, None, u'"constant"', []), (1, None, u'%(foo)s', [])],
+            [(1, None, u'constant', []), (1, None, u'%(foo)s', [])],
             messages,
         )
 


### PR DESCRIPTION
If you have translation in template like _("Fox"), then django-babel will extract string with quotes: "Fox". This pull-request strips quotes from message, so extracted string will be Fox