### PR TITLE
Support Django 1.11 and refactor travis/tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,9 @@ python:
 
 matrix:
    include:
-      - env: TOX_ENV=docs
+      - env: TOXENV=docs
         python: '3.6'
-      - env: TOX_ENV=lint
+      - env: TOXENV=lint
         python: '3.6'
   
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,4 @@ matrix:
 install:
 - pip install tox tox-travis
 script:
-- tox -e $TOX_ENV
+- tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python: 3.6
 sudo: false
+cache: pip
 env:
   - TOX_ENV=docs
   - TOX_ENV=lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: python
-python: 3.4
+python: 3.6
 sudo: false
 env:
   - TOX_ENV=docs
@@ -19,6 +19,12 @@ env:
   - TOX_ENV=py35-django110
   - TOX_ENV=py35-django111
   - TOX_ENV=py35-djangomaster
+  - TOX_ENV=py36-django18
+  - TOX_ENV=py36-django19
+  - TOX_ENV=py36-django110
+  - TOX_ENV=py36-django111
+  - TOX_ENV=py36-djangomaster
+  
 install:
 - pip install tox
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,19 @@ env:
   - TOX_ENV=py27-django18
   - TOX_ENV=py27-django19
   - TOX_ENV=py27-django110
+  - TOX_ENV=py27-django111
   - TOX_ENV=py27-djangomaster
   - TOX_ENV=py33-django18
   - TOX_ENV=py34-django18
   - TOX_ENV=py34-django19
   - TOX_ENV=py34-django110
+  - TOX_ENV=py34-django111
   - TOX_ENV=py34-djangomaster
+  - TOX_ENV=py35-django18
+  - TOX_ENV=py35-django19
+  - TOX_ENV=py35-django110
+  - TOX_ENV=py35-django111
+  - TOX_ENV=py35-djangomaster
 install:
 - pip install tox
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ env:
   - TOX_ENV=py27-django19
   - TOX_ENV=py27-django110
   - TOX_ENV=py27-django111
-  - TOX_ENV=py27-djangomaster
   - TOX_ENV=py33-django18
   - TOX_ENV=py34-django18
   - TOX_ENV=py34-django19

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: python
-python: 3.6
 sudo: false
 cache: pip
 
@@ -11,15 +10,12 @@ python:
 
 matrix:
    include:
-      - TOX_ENV=docs
+      - env: TOX_ENV=docs
         python: '3.6'
-      - TOX_ENV=lint
+      - env: TOX_ENV=lint
         python: '3.6'
   
 install:
 - pip install tox tox-travis
 script:
 - tox -e $TOX_ENV
-cache:
-  directories:
-    - $HOME/.cache/pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,32 +2,22 @@ language: python
 python: 3.6
 sudo: false
 cache: pip
-env:
-  - TOX_ENV=docs
-  - TOX_ENV=lint
-  - TOX_ENV=py27-django18
-  - TOX_ENV=py27-django19
-  - TOX_ENV=py27-django110
-  - TOX_ENV=py27-django111
-  - TOX_ENV=py33-django18
-  - TOX_ENV=py34-django18
-  - TOX_ENV=py34-django19
-  - TOX_ENV=py34-django110
-  - TOX_ENV=py34-django111
-  - TOX_ENV=py34-djangomaster
-  - TOX_ENV=py35-django18
-  - TOX_ENV=py35-django19
-  - TOX_ENV=py35-django110
-  - TOX_ENV=py35-django111
-  - TOX_ENV=py35-djangomaster
-  - TOX_ENV=py36-django18
-  - TOX_ENV=py36-django19
-  - TOX_ENV=py36-django110
-  - TOX_ENV=py36-django111
-  - TOX_ENV=py36-djangomaster
+
+python:
+   - '2.7'
+   - '3.4'
+   - '3.5'
+   - '3.6'
+
+matrix:
+   include:
+      - TOX_ENV=docs
+        python: '3.6'
+      - TOX_ENV=lint
+        python: '3.6'
   
 install:
-- pip install tox
+- pip install tox tox-travis
 script:
 - tox -e $TOX_ENV
 cache:

--- a/django_babel/extract.py
+++ b/django_babel/extract.py
@@ -4,12 +4,12 @@ from django.utils.translation import trim_whitespace
 from django.utils.encoding import smart_text
 
 try:
-   from django.utils.translation.trans_real import (
-      inline_re, block_re, endblock_re, plural_re, constant_re)
+    from django.utils.translation.trans_real import (
+        inline_re, block_re, endblock_re, plural_re, constant_re)
 except ImportError:
-   # Django 1.11+
-   from django.utils.translation.template import (
-      inline_re, block_re, endblock_re, plural_re, constant_re)
+    # Django 1.11+
+    from django.utils.translation.template import (
+        inline_re, block_re, endblock_re, plural_re, constant_re)
 
 
 def join_tokens(tokens, trim=False):

--- a/django_babel/extract.py
+++ b/django_babel/extract.py
@@ -20,6 +20,7 @@ except ImportError:
     from django.utils.translation.template import (
         inline_re, block_re, endblock_re, plural_re, constant_re)
 
+
 def trim_whitespace(string):
     """Trim whitespace.
 

--- a/django_babel/extract.py
+++ b/django_babel/extract.py
@@ -1,35 +1,15 @@
 # -*- coding: utf-8 -*-
-try:
-    from django.template import Lexer, TOKEN_TEXT, TOKEN_VAR, TOKEN_BLOCK
-except ImportError:
-    # Django 1.8 moved most stuff to .base
-    from django.template.base import Lexer, TOKEN_TEXT, TOKEN_VAR, TOKEN_BLOCK
-
-try:
-    from django.utils.translation import trim_whitespace as trim_django
-except ImportError:
-    trim_django = False
-
+from django.template.base import Lexer, TOKEN_TEXT, TOKEN_VAR, TOKEN_BLOCK
+from django.utils.translation import trim_whitespace
 from django.utils.encoding import smart_text
 
 try:
-    from django.utils.translation.trans_real import (
-        inline_re, block_re, endblock_re, plural_re, constant_re)
+   from django.utils.translation.trans_real import (
+      inline_re, block_re, endblock_re, plural_re, constant_re)
 except ImportError:
-    # Django 1.11+
-    from django.utils.translation.template import (
-        inline_re, block_re, endblock_re, plural_re, constant_re)
-
-
-def trim_whitespace(string):
-    """Trim whitespace.
-
-    This is only supported in Django>=1.7. This method help in cases of older
-    Django versions.
-    """
-    if trim_django:
-        return trim_django(string)
-    return string
+   # Django 1.11+
+   from django.utils.translation.template import (
+      inline_re, block_re, endblock_re, plural_re, constant_re)
 
 
 def join_tokens(tokens, trim=False):

--- a/django_babel/extract.py
+++ b/django_babel/extract.py
@@ -1,9 +1,34 @@
 # -*- coding: utf-8 -*-
-from django.template.base import Lexer, TOKEN_TEXT, TOKEN_VAR, TOKEN_BLOCK
-from django.utils.translation import trim_whitespace
+try:
+    from django.template import Lexer, TOKEN_TEXT, TOKEN_VAR, TOKEN_BLOCK
+except ImportError:
+    # Django 1.8 moved most stuff to .base
+    from django.template.base import Lexer, TOKEN_TEXT, TOKEN_VAR, TOKEN_BLOCK
+
+try:
+    from django.utils.translation import trim_whitespace as trim_django
+except ImportError:
+    trim_django = False
+
 from django.utils.encoding import smart_text
-from django.utils.translation.trans_real import (
-    inline_re, block_re, endblock_re, plural_re, constant_re)
+
+try:
+    from django.utils.translation.trans_real import (
+        inline_re, block_re, endblock_re, plural_re, constant_re)
+except ImportError:
+    # Django 1.11+
+    from django.utils.translation.template import (
+        inline_re, block_re, endblock_re, plural_re, constant_re)
+
+def trim_whitespace(string):
+    """Trim whitespace.
+
+    This is only supported in Django>=1.7. This method help in cases of older
+    Django versions.
+    """
+    if trim_django:
+        return trim_django(string)
+    return string
 
 
 def join_tokens(tokens, trim=False):

--- a/django_babel/templatetags/babel.py
+++ b/django_babel/templatetags/babel.py
@@ -32,41 +32,41 @@ def _get_format():
     return babel_support.Format(locale, tzinfo)
 
 
+@register.filter
 def datefmt(date=None, format='medium'):
     return _get_format().date(date, format=format)
-datefmt = register.filter(datefmt)
 
 
+@register.filter
 def datetimefmt(datetime=None, format='medium'):
     return _get_format().datetime(datetime, format=format)
-datetimefmt = register.filter(datetimefmt)
 
 
+@register.filter
 def timefmt(time=None, format='medium'):
     return _get_format().time(time, format=format)
-timefmt = register.filter(timefmt)
 
 
+@register.filter
 def numberfmt(number):
     return _get_format().number(number)
-numberfmt = register.filter(numberfmt)
 
 
+@register.filter
 def decimalfmt(number, format=None):
     return _get_format().decimal(number, format=format)
-decimalfmt = register.filter(decimalfmt)
 
 
+@register.filter
 def currencyfmt(number, currency):
     return _get_format().currency(number, currency)
-currencyfmt = register.filter(currencyfmt)
 
 
+@register.filter
 def percentfmt(number, format=None):
     return _get_format().percent(number, format=format)
-percentfmt = register.filter(percentfmt)
 
 
+@register.filter
 def scientificfmt(number):
     return _get_format().scientific(number)
-scientificfmt = register.filter(scientificfmt)

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     url='https://github.com/python-babel/django-babel/',
     packages=find_packages(exclude=('tests',)),
     install_requires=[
-        'django>=1.4,<1.11',
+        'django>=1.4,<1.12',
         'babel>=1.3',
     ],
     classifiers=[

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ deps =
     djangomaster: https://github.com/django/django/archive/master.tar.gz#egg=Django
 commands = py.test {posargs}
 
-[tox:travis]
+[python]
 2.7 = py27
 3.4 = py34
 3.5 = py35

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py27,py34,py35,py36}-django{18,19,110,111,master}, py33-django18, lint, docs
+envlist = {py27,py34,py35,py36}-django{18,19,110,111}, lint, docs
 
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py27,py34,py35}-django{18,19,110,master}, py33-django18, lint, docs
+envlist = {py27,py34,py35}-django{18,19,110,111,master}, py33-django18, lint, docs
 
 [testenv]
 deps =
@@ -8,9 +8,10 @@ deps =
     pytest-cov
     pytest-django
     python-coveralls
-    django18: Django>=1.8,<1.9
-    django19: Django>=1.9,<1.10
-    django110: Django>=1.10,<1.11
+    django18: Django~=1.8
+    django19: Django~=1.9
+    django110: Django~=1.10
+    django111: Django~=1.11
     djangomaster: https://github.com/django/django/archive/master.tar.gz#egg=Django
 commands = py.test {posargs}
 
@@ -22,5 +23,5 @@ commands =
 
 [testenv:lint]
 deps =
-    flake8==2.4.1
+    flake8
 commands=flake8 django_babel tests

--- a/tox.ini
+++ b/tox.ini
@@ -8,10 +8,10 @@ deps =
     pytest-cov
     pytest-django
     python-coveralls
-    django18: Django~=1.8
-    django19: Django~=1.9
-    django110: Django~=1.10
-    django111: Django~=1.11
+    django18: Django>=1.8,<1.9
+    django19: Django>=1.9,<1.10
+    django110: Django>=1.10,<1.11
+    django111: Django>=1.11,<1.12
     djangomaster: https://github.com/django/django/archive/master.tar.gz#egg=Django
 commands = py.test {posargs}
 

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,6 @@ deps =
     django19: Django>=1.9,<1.10
     django110: Django>=1.10,<1.11
     django111: Django>=1.11,<1.12
-    djangomaster: https://github.com/django/django/archive/master.tar.gz#egg=Django
 commands = py.test {posargs}
 
 [python]

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,12 @@ deps =
     djangomaster: https://github.com/django/django/archive/master.tar.gz#egg=Django
 commands = py.test {posargs}
 
+[tox:travis]
+2.7 = py27
+3.4 = py34
+3.5 = py35
+3.6 = py36
+
 [testenv:docs]
 deps = sphinx
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py27,py34,py35}-django{18,19,110,111,master}, py33-django18, lint, docs
+envlist = {py27,py34,py35,py36}-django{18,19,110,111,master}, py33-django18, lint, docs
 
 [testenv]
 deps =


### PR DESCRIPTION
I refactored the `.travis.yml` file to be a bit cleaner. I also added support for Django 1.11 (an import was broken), and fixed the flake8 violations that where in the project.