### PR TITLE
Percent signs escaping in templatetags

### DIFF
--- a/django_babel/extract.py
+++ b/django_babel/extract.py
@@ -1,7 +1,16 @@
 # -*- coding: utf-8 -*-
-from django.template.base import Lexer, TOKEN_TEXT, TOKEN_VAR, TOKEN_BLOCK
+from django.template.base import Lexer
 from django.utils.translation import trim_whitespace
 from django.utils.encoding import smart_text
+
+try:
+    from django.template.base import TOKEN_TEXT, TOKEN_VAR, TOKEN_BLOCK
+except ImportError:
+    # Django 2.1+
+    from django.template.base import TokenType
+    TOKEN_TEXT = TokenType.TEXT
+    TOKEN_VAR = TokenType.VAR
+    TOKEN_BLOCK = TokenType.BLOCK
 
 try:
     from django.utils.translation.trans_real import (

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -218,3 +218,33 @@ class ExtractDjangoTestCase(unittest.TestCase):
         buf = BytesIO(test_tmpl)
         messages = list(extract_django(buf, default_keys, [], {}))
         self.assertEqual([(4, None, u'foo bar', [])], messages)
+
+    @pytest.mark.skipif(django.VERSION >= (1, 9),
+                        reason='%-sign escaping changed in django 1.9')
+    def test_extract_trans_percents_old_way(self):
+        """Before Django 1.9, only a signle %-sign was escaped to %%"""
+        buf = BytesIO(b'{% trans "1 %, 2 %%, 3 %%%" %}')
+        messages = list(extract_django(buf, default_keys, [], {}))
+        self.assertEqual([(1, None, u'1 %%, 2 %%, 3 %%%', [])], messages)
+
+    @pytest.mark.skipif(django.VERSION >= (1, 9),
+                        reason='%-sign escaping changed in django 1.9')
+    def test_extract_blocktrans_percents_old_way(self):
+        """Before Django 1.9, only a signle %-sign was escaped to %%"""
+        buf = BytesIO(b'{% blocktrans %}1 %, 2 %%, 3 %%%{% endblocktrans %}')
+        messages = list(extract_django(buf, default_keys, [], {}))
+        self.assertEqual([(1, None, u'1 %%, 2 %%, 3 %%%', [])], messages)
+
+    @pytest.mark.skipif(django.VERSION < (1, 9),
+                        reason='%-sign escaping changed in django 1.9')
+    def test_extract_trans_percents(self):
+        buf = BytesIO(b'{% trans "1 %, 2 %%, 3 %%%" %}')
+        messages = list(extract_django(buf, default_keys, [], {}))
+        self.assertEqual([(1, None, u'1 %%, 2 %%%%, 3 %%%%%%', [])], messages)
+
+    @pytest.mark.skipif(django.VERSION < (1, 9),
+                        reason='%-sign escaping changed in django 1.9')
+    def test_extract_blocktrans_percents(self):
+        buf = BytesIO(b'{% blocktrans %}1 %, 2 %%, 3 %%%{% endblocktrans %}')
+        messages = list(extract_django(buf, default_keys, [], {}))
+        self.assertEqual([(1, None, u'1 %%, 2 %%%%, 3 %%%%%%', [])], messages)


### PR DESCRIPTION
Closes https://github.com/python-babel/django-babel/issues/43

In Django >= 1.9, `%` signs are escaped to `%%` during extraction
then replaced by `%` during the rendering. [1]
Before Django 1.9, only single percent signs were escaped.

The extraction now behaves in the same way.

[1] https://github.com/django/django/commit/b7508896fbe19ec2cdeb81565cd587091b6b68d0